### PR TITLE
Fixed for @testable import sorts.

### DIFF
--- a/Core/RunnableItems/SortGenerate.swift
+++ b/Core/RunnableItems/SortGenerate.swift
@@ -19,19 +19,21 @@ final class SortGenerate: Runnable {
         // Implement your command here, invoking the completion handler when done. Pass it nil on success, and an NSError on failure.
         guard let lines = lines else { return }
         let bridgedLines = lines.compactMap { $0 as? String }
-
+        
         let importFrameworks = bridgedLines.enumerated().compactMap({
             $0.element.isImportLine ? $0.element.removeImportPrefix.removeNewLine : nil
         }).sorted()
-
+        
+        let sortedImports = importFrameworks.map { "import \($0)" }.sorted()
+        
         let importIndex = bridgedLines.enumerated().compactMap({
             $0.element.isImportLine ? $0.offset : nil
         }).sorted()
-
-        guard importIndex.count == importFrameworks.count && lines.count > importIndex.count else {
+        
+        guard importIndex.count == sortedImports.count && lines.count > importIndex.count else {
             return
         }
-        importFrameworks.enumerated().forEach({ lines[importIndex[$0]] = "import \($1)" })
+        sortedImports.enumerated().forEach({ lines[importIndex[$0]] = $1 })
     }
 }
 


### PR DESCRIPTION
In our case, if there was "@testable import" it would cause it to be sorted incorrectly.
![Screen Recording 2023-12-28 at 15 14 24](https://github.com/aytugsevgi/SwityTestGenerator/assets/59478623/c431d039-a805-4e4b-a82c-07aea59faab1)
